### PR TITLE
Validation suggestion improvement

### DIFF
--- a/pgmultiauth.go
+++ b/pgmultiauth.go
@@ -22,9 +22,10 @@ const (
 	NoAuth     AuthMethod = iota // Default value, no authentication
 	AWSIAMAuth                   // AWS IAM authentication
 	GCPAuth                      // GCP authentication
-	AzureAuth
+	AzureAuth                    // Azure authentication
 )
 
+// AuthConfig holds the configuration for database authentication.
 type AuthConfig struct {
 	DatabaseURL string
 	Logger      hclog.Logger


### PR DESCRIPTION
This PR suggests an improvement in the way the validation is done by using enums instead of booleans.
This way, the struct can be passed in like this instead:

```
     authConfig := pgmultiauth.AuthConfig{
     DatabaseURL: "dburl",
     Logger: logger,
     AuthMethod: pgmultiauth.AWSIAMAuth, // To use AWS IAM auth for example instead of checking for boolean field `true`
     AWSDBRegion: "us-east-1",
}
```