### PR TITLE
refactoring lock and method name

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -24,7 +24,7 @@ func getAWSAuthToken(config awsTokenConfig, logger hclog.Logger) (*authToken, er
 	err := retry.Do(
 		func() error {
 			var err error
-			token, err = fetchAuthToken(config)
+			token, err = fetchAWSAuthToken(config)
 			return err
 		},
 		retry.Attempts(3),
@@ -46,7 +46,7 @@ func getAWSAuthToken(config awsTokenConfig, logger hclog.Logger) (*authToken, er
 	return &authToken{token: token, valid: validFn}, nil
 }
 
-func fetchAuthToken(config awsTokenConfig) (string, error) {
+func fetchAWSAuthToken(config awsTokenConfig) (string, error) {
 	awsConfig := &aws.Config{
 		Region: aws.String(config.dbRegion),
 	}

--- a/pgmultiauth.go
+++ b/pgmultiauth.go
@@ -167,9 +167,18 @@ func BeforeConnectFn(authConfig AuthConfig) (func(context.Context, *pgx.ConnConf
 		var tokenMutex sync.Mutex
 
 		beforeConnect = func(ctx context.Context, config *pgx.ConnConfig) error {
+			// no point in contending for lock if we know the token is valid
+			if token.valid() {
+				config.Password = token.token
+				return nil
+			}
+
+			// acquire lock if token is not valid
 			tokenMutex.Lock()
 			defer tokenMutex.Unlock()
 
+			// necessary because multiple connections in the pool might be waiting to acquire tokenMutex after finding the token invalid
+			// and the token might have been refreshed by a connection that acquired the lock first
 			if !token.valid() {
 				authConfig.Logger.Info("refreshing db token")
 				token, err = getAuthToken(authConfig)


### PR DESCRIPTION
- Refactored locks to avoid contention when there is no need to.
- Refactored `fetcAuthToken` to `fetchAWSAuthToken` in line with other methods for other clouds