### PR TITLE
Support for default cloud config

### DIFF
--- a/default.go
+++ b/default.go
@@ -1,0 +1,100 @@
+package pgmultiauth
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/hashicorp/go-hclog"
+	"golang.org/x/oauth2/google"
+)
+
+// CloudAuthConfigOptions holds the configuration options for cloud authentication
+// when application is running in a cloud environment.
+type CloudAuthConfigOptions struct {
+	UseAWSIAM                bool
+	UseGCPDefaultCredentials bool
+	UseAzureMSI              bool
+
+	// AWS IAM Auth
+	AWSDBRegion string
+
+	// Azure MSI Auth
+	AzureClientID string
+}
+
+// DefaultCloudAuthConfig initializes AuthConfig with default behavior across the clouds. It assumes that application
+// is running in a cloud environment and uses the appropriate authentication method based on the provided options.
+// For AWS, it uses AWS IAM authentication
+// For GCP, it uses GCP default credentials
+// For Azure, it uses Managed Identity (MSI) authentication
+// For NoAuth, it uses the default PostgreSQL authentication
+func DefaultCloudAuthConfig(dbURL string, logger hclog.Logger, opts CloudAuthConfigOptions) (AuthConfig, error) {
+	authMode := GetAuthMode(opts.UseAWSIAM, opts.UseGCPDefaultCredentials, opts.UseAzureMSI)
+
+	var googleCreds *google.Credentials
+	var azureCreds azcore.TokenCredential
+	var awsConfig *aws.Config
+
+	if authMode == AWSIAMAuth {
+		if opts.AWSDBRegion == "" {
+			return AuthConfig{}, fmt.Errorf("AWSDBRegion is required for AWS IAM authentication")
+		}
+
+		sess, err := session.NewSession(&aws.Config{
+			Region: aws.String(opts.AWSDBRegion),
+		})
+		if err != nil {
+			return AuthConfig{}, fmt.Errorf("failed to create AWS session: %v", err)
+		}
+
+		awsConfig = sess.Config
+	} else if authMode == GCPAuth {
+		ctx := context.Background()
+		creds, err := google.FindDefaultCredentials(ctx, "https://www.googleapis.com/auth/cloud-platform")
+		if err != nil {
+			return AuthConfig{}, fmt.Errorf("failed to get GCP credentials: %v", err)
+		}
+		googleCreds = creds
+	} else if authMode == AzureAuth {
+		msiCredOpts := &azidentity.ManagedIdentityCredentialOptions{}
+		if opts.AzureClientID != "" {
+			msiCredOpts.ID = azidentity.ClientID(opts.AzureClientID)
+		}
+
+		msiCreds, err := azidentity.NewManagedIdentityCredential(msiCredOpts)
+		if err != nil {
+			return AuthConfig{}, fmt.Errorf("failed to create Azure managed identity credential: %v", err)
+		}
+
+		azureCreds = msiCreds
+	}
+
+	return AuthConfig{
+		DatabaseURL: dbURL,
+		Logger:      logger,
+		AuthMethod:  authMode,
+		AWSConfig:   awsConfig,
+		AzureCreds:  azureCreds,
+		GoogleCreds: googleCreds,
+	}, nil
+}
+
+// GetAuthMode returns the authentication method based on the provided flags.
+// It prioritizes AWS IAM authentication, followed by GCP and Azure authentication.
+// If none of the flags are set, it returns NoAuth.
+func GetAuthMode(useAWSIAMAuth bool, useGCPAuth bool, useAzureAuth bool) AuthMethod {
+	switch {
+	case useAWSIAMAuth:
+		return AWSIAMAuth
+	case useGCPAuth:
+		return GCPAuth
+	case useAzureAuth:
+		return AzureAuth
+	default:
+		return NoAuth
+	}
+}

--- a/pgmultiauth.go
+++ b/pgmultiauth.go
@@ -237,22 +237,6 @@ func GetConnectionURL(authConfig AuthConfig) (string, error) {
 	return tokenBasedURL, nil
 }
 
-// GetAuthMode returns the authentication method based on the provided flags.
-// It prioritizes AWS IAM authentication, followed by GCP and Azure authentication.
-// If none of the flags are set, it returns NoAuth.
-func GetAuthMode(useAWSIAMAuth bool, useGCPAuth bool, useAzureAuth bool) AuthMethod {
-	switch {
-	case useAWSIAMAuth:
-		return AWSIAMAuth
-	case useGCPAuth:
-		return GCPAuth
-	case useAzureAuth:
-		return AzureAuth
-	default:
-		return NoAuth
-	}
-}
-
 // getAuthTokenWithRetry attempts to fetch an authentication token
 // with retries in case of failure. It uses exponential backoff
 // for retrying the request.


### PR DESCRIPTION
This PR adds support for `DefaultCloudAuthConfig` function.
The function helps in getting the auth config assuming the application is running in the cloud environment.

-  For AWS, it uses AWS IAM authentication
-  For GCP, it uses GCP default credentials
-  For Azure, it uses Managed Identity (MSI) authentication
-  For NoAuth, it uses the default PostgreSQL authentication

This can be used by clients when the application is running in the cloud and want to use the identity based auth(IAM, MSI etc)