### PR TITLE
Validation of region and credentials for awsConfig

### DIFF
--- a/aws.go
+++ b/aws.go
@@ -45,3 +45,19 @@ func (c awsTokenConfig) fetchAWSAuthToken() (string, error) {
 
 	return authToken, nil
 }
+
+func validateAWSConfig(awsConfig *aws.Config) error {
+	if awsConfig == nil {
+		return fmt.Errorf("aws config is required for AWS authentication")
+	}
+
+	if awsConfig.Region == nil {
+		return fmt.Errorf("aws region is required for AWS authentication")
+	}
+
+	if awsConfig.Credentials == nil {
+		return fmt.Errorf("aws credentials are required for AWS authentication")
+	}
+
+	return nil
+}

--- a/azure.go
+++ b/azure.go
@@ -37,3 +37,11 @@ func (c azureTokenConfig) fetchAzureAuthToken() (azcore.AccessToken, error) {
 
 	return token, nil
 }
+
+func validateAzureConfig(creds azcore.TokenCredential) error {
+	if creds == nil {
+		return fmt.Errorf("azure credentials are required for Azure authentication")
+	}
+
+	return nil
+}

--- a/gcp.go
+++ b/gcp.go
@@ -30,3 +30,15 @@ func (c gcpTokenConfig) fetchGCPAuthToken() (*oauth2.Token, error) {
 
 	return token, nil
 }
+
+func validateGCPConfig(creds *google.Credentials) error {
+	if creds == nil {
+		return fmt.Errorf("gcp credentials are required for GCP authentication")
+	}
+
+	if creds.TokenSource == nil {
+		return fmt.Errorf("gcp token source is required for GCP authentication")
+	}
+
+	return nil
+}

--- a/pgmultiauth.go
+++ b/pgmultiauth.go
@@ -68,22 +68,16 @@ func (c Config) validate() error {
 	case StandardAuth:
 		// No additional validation needed for StandardAuth
 	case AWSAuth:
-		if c.AWSConfig == nil {
-			return fmt.Errorf("AWSConfig is required when AuthMethod is AWSAuth")
-		}
-		if c.AWSConfig.Region == nil {
-			return fmt.Errorf("region is required in AWSConfig when AuthMethod is AWSAuth")
-		}
-		if c.AWSConfig.Credentials == nil {
-			return fmt.Errorf("credentials are required in AWSConfig when AuthMethod is AWSAuth")
+		if err := validateAWSConfig(c.AWSConfig); err != nil {
+			return fmt.Errorf("invalid AWS config: %v", err)
 		}
 	case AzureAuth:
-		if c.AzureCreds == nil {
-			return fmt.Errorf("AzureCreds is required when AuthMethod is AzureAuth")
+		if err := validateAzureConfig(c.AzureCreds); err != nil {
+			return fmt.Errorf("invalid Azure config: %v", err)
 		}
 	case GCPAuth:
-		if c.GoogleCreds == nil {
-			return fmt.Errorf("GoogleCreds is required when AuthMethod is GCPAuth")
+		if err := validateGCPConfig(c.GoogleCreds); err != nil {
+			return fmt.Errorf("invalid GCP config: %v", err)
 		}
 	default:
 		return fmt.Errorf("unsupported authentication method: %d", c.AuthMethod)

--- a/pgmultiauth_test.go
+++ b/pgmultiauth_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/hashicorp/go-hclog"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 )
 
@@ -48,7 +49,9 @@ func Test_Config_validate(t *testing.T) {
 				DatabaseURL: "postgres://user@host:5432/db",
 				Logger:      logger,
 				AuthMethod:  GCPAuth,
-				GoogleCreds: &google.Credentials{},
+				GoogleCreds: &google.Credentials{
+					TokenSource: oauth2.StaticTokenSource(&oauth2.Token{}),
+				},
 			},
 			expectedErr: false,
 		},
@@ -90,7 +93,7 @@ func Test_Config_validate(t *testing.T) {
 				AuthMethod:  AWSAuth,
 			},
 			expectedErr: true,
-			errContains: "AWSConfig is required when AuthMethod is AWSAuth",
+			errContains: "invalid AWS config: aws config is required for AWS authentication",
 		},
 		{
 			name: "AWS auth without region in aws config",
@@ -103,7 +106,7 @@ func Test_Config_validate(t *testing.T) {
 				},
 			},
 			expectedErr: true,
-			errContains: "region is required in AWSConfig when AuthMethod is AWSAuth",
+			errContains: "invalid AWS config: aws region is required for AWS authentication",
 		},
 		{
 			name: "AWS auth without credentials in aws config",
@@ -116,7 +119,7 @@ func Test_Config_validate(t *testing.T) {
 				},
 			},
 			expectedErr: true,
-			errContains: "credentials are required in AWSConfig when AuthMethod is AWSAuth",
+			errContains: "invalid AWS config: aws credentials are required for AWS authentication",
 		},
 		{
 			name: "Azure auth without AzureCreds",
@@ -126,7 +129,17 @@ func Test_Config_validate(t *testing.T) {
 				AuthMethod:  AzureAuth,
 			},
 			expectedErr: true,
-			errContains: "AzureCreds is required when AuthMethod is AzureAuth",
+			errContains: "invalid Azure config: azure credentials are required for Azure authentication",
+		},
+		{
+			name: "GCP auth without Credentials",
+			config: Config{
+				DatabaseURL: "postgres://user@host:5432/db",
+				Logger:      logger,
+				AuthMethod:  GCPAuth,
+			},
+			expectedErr: true,
+			errContains: "invalid GCP config: gcp credentials are required for GCP authentication",
 		},
 		{
 			name: "Unsupported auth method",


### PR DESCRIPTION
This PR adds validation of region and credentials for awsConfig.
This will avoid possible nil pointer deference