### PR TITLE
Adding support for Workload Identity in Azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The module currently supports:
 
 - **AWS  Authentication**: [For RDS and Aurora PostgreSQL instances](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html)
 - **GCP Authentication**: [For Cloud SQL PostgreSQL instances](https://cloud.google.com/sql/docs/postgres/iam-authentication)
-- **Azure Authentication**: [For Azure Database for PostgreSQL](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-connect-with-managed-identity)
+- **Azure Authentication**: [For Azure Database for PostgreSQL(Managed Identity)](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/how-to-connect-with-managed-identity), [Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)
 
 ## Installation
 


### PR DESCRIPTION
## Background

This PR adds support for workload identity in AKS when using default behaviour.

AKS supports workload identity for passwordless auth. Currently supported Managed Identity is insecure as it exposes access to other pods in the Node Pool.

## How Has This Been Tested

This has been tested by creating an AKS cluster and running the Azure based integration test on it.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [ ] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
